### PR TITLE
Bugfix: context.handlers can get overwritten during requext execution causing the wrong handler to be executed

### DIFF
--- a/router.go
+++ b/router.go
@@ -149,11 +149,14 @@ func (r *Router) Handle(method string, pattern string, handlers []Handler) {
 	}
 	validateHandlers(handlers)
 
+	contextHandlers := make([]Handler, 0)
+	contextHandlers = append(contextHandlers, r.m.handlers...)
+	contextHandlers = append(contextHandlers, handlers...)
+
 	r.handle(method, pattern, func(resp http.ResponseWriter, req *http.Request, params Params) {
 		c := r.m.createContext(resp, req)
 		c.params = params
-		c.handlers = append(c.handlers, r.m.handlers...)
-		c.handlers = append(c.handlers, handlers...)
+		c.handlers = contextHandlers
 		c.run()
 	})
 }

--- a/router.go
+++ b/router.go
@@ -152,7 +152,8 @@ func (r *Router) Handle(method string, pattern string, handlers []Handler) {
 	r.handle(method, pattern, func(resp http.ResponseWriter, req *http.Request, params Params) {
 		c := r.m.createContext(resp, req)
 		c.params = params
-		c.handlers = append(r.m.handlers, handlers...)
+		c.handlers = append(c.handlers, r.m.handlers...)
+		c.handlers = append(c.handlers, handlers...)
 		c.run()
 	})
 }


### PR DESCRIPTION
Bug symptom:

```go
m.Get("/api/account", auth, GetAccount)
m.Get("/api/account/others", auth, GetOtherAccounts)
```
Given two routes like this, if the ``/api/accounts/others`` requests comes in as the ``/api/account/`` requests executes it may override the context.handlers slice underlying backing array and cause the ``/api/account`` request to be routed to the GetOtherAccounts handler method. 	

This is caused by this line (router:L155): 

```go
c.handlers = append(r.m.handlers, handlers...)
```

This line is dangerous as it has the ``r.m.handlers`` as the first parameter, ``r.m.handlers`` is reused between requests. append will see that there is room in the underlying array for ``r.m.handlers`` and reuse that space, but that space might already be used for another handler in another request. 

http://golang.org/pkg/builtin/#append

Not directly related but this issue touches on similar issue:
https://github.com/golang/go/issues/9458

